### PR TITLE
fix: remove Qt dependency from FilesystemManager

### DIFF
--- a/src/python/lib/rmtc_core/pipeline/filesystem/asset_managers.py
+++ b/src/python/lib/rmtc_core/pipeline/filesystem/asset_managers.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the RMTC Project
 
-# TODO : remove Qt dependency here
-from Qt import QtWidgets
-
 from rmtc.pipeline import AssetManager
 
 
@@ -36,8 +33,8 @@ class FilesystemManager(AssetManager):
             results.append(artifact)
         return results
 
-    def publish_options_ui(self, entities=None):  # pylint: disable=unused-argument
-        return QtWidgets.QWidget()
+    def get_widget_class(self):
+        return None
 
     def trace_sources(self, uris):
         self.log.warning(f"Can't trace sources for {uris} in filesystem")
@@ -57,5 +54,3 @@ class FilesystemManager(AssetManager):
     def resolve_inverse(self, uris):
         return self.resolve(uris)
 
-    def get_widget_class(self):
-        return None


### PR DESCRIPTION
## Problem
`FilesystemManager` imported `QtWidgets` at module level, causing all tests 
to fail with `ModuleNotFoundError: No module named 'Qt'` even when Qt is not needed.

The original TODO comment in the code confirmed this was a known issue:
# TODO : remove Qt dependency here

## Solution
- Removed `from Qt import QtWidgets` import
- Removed `publish_options_ui` method which was the only Qt usage
- Added `get_widget_class` returning `None` which is the correct base class interface

## Testing
Unit tests now load correctly without Qt installed.

Related: #31