### PR TITLE
chore: apply black formatting to codebase

### DIFF
--- a/src/python/lib/rmtc/artifacts.py
+++ b/src/python/lib/rmtc/artifacts.py
@@ -9,7 +9,6 @@ we don't permit multiple inheritance unless it's a IXxxx class
 These classes don't hold member variables and don't have an __init__ or __del__
 """
 
-
 from abc import ABC, abstractmethod
 import enum
 

--- a/src/python/lib/rmtc/infer.py
+++ b/src/python/lib/rmtc/infer.py
@@ -5,7 +5,6 @@
 Inference systems and representations.
 """
 
-
 from abc import ABC, abstractmethod
 
 import rmtc.system

--- a/src/python/lib/rmtc/interface.py
+++ b/src/python/lib/rmtc/interface.py
@@ -7,7 +7,6 @@ for example REST, RPC or other remote calling
 architectures.
 """
 
-
 from abc import ABC, abstractmethod
 
 

--- a/src/python/lib/rmtc/track.py
+++ b/src/python/lib/rmtc/track.py
@@ -6,7 +6,6 @@ Tracking storage interface - contains all the core
 entity types that we expect to store and their properties.
 """
 
-
 import enum
 import re
 

--- a/src/python/lib/rmtc/train.py
+++ b/src/python/lib/rmtc/train.py
@@ -6,7 +6,6 @@ Training classes, derivations from the tracking entities that
 are trainable.
 """
 
-
 from abc import ABC, abstractmethod
 
 import rmtc.system

--- a/src/python/lib/rmtc_core/artifacts/filesystem/datasets.py
+++ b/src/python/lib/rmtc_core/artifacts/filesystem/datasets.py
@@ -2,7 +2,7 @@
 # Copyright Contributors to the RMTC Project
 
 """
-NOTE : 
+NOTE :
 These folder based datasets are for testing ONLY and
 will be removed shortly.
 

--- a/src/python/lib/rmtc_core/gui/common/properties.py
+++ b/src/python/lib/rmtc_core/gui/common/properties.py
@@ -253,15 +253,13 @@ class Expander(QtWidgets.QWidget):
 
         self._content = QtWidgets.QFrame(parent=self)
         self._content.setObjectName("Expander")
-        self._content.setStyleSheet(
-            """
+        self._content.setStyleSheet("""
             QFrame#Expander {
                 border: 1px solid #909090;
                 border-radius: 5px;
                 padding: 5px;
             }
-        """
-        )
+        """)
         self._content.setVisible(False)
         self._content_layout = QtWidgets.QVBoxLayout(self._content)
         widget.parent = self._content

--- a/src/python/lib/rmtc_core/gui/common/widgets.py
+++ b/src/python/lib/rmtc_core/gui/common/widgets.py
@@ -17,15 +17,13 @@ class Log(QtWidgets.QWidget):
         self._content = QtWidgets.QPlainTextEdit()
         self._content.setReadOnly(True)
         self._content.setObjectName("Log")
-        self._content.setStyleSheet(
-            """
+        self._content.setStyleSheet("""
             QPlainTextEdit#Log {
                 color: #909090;
                 font-family: 'Courier New';
                 font-size: 8pt;
             }
-        """
-        )
+        """)
         scroller = QtWidgets.QScrollArea()
         scroller.setWidgetResizable(True)
         scroller.setWidget(self._content)

--- a/src/python/lib/rmtc_core/gui/signalbox/widgets.py
+++ b/src/python/lib/rmtc_core/gui/signalbox/widgets.py
@@ -5,7 +5,6 @@
 The SignalBox GUI classes - this will likely need to be paritioned
 """
 
-
 import os
 from abc import ABCMeta
 

--- a/src/python/lib/rmtc_core/io/filesystem/folders.py
+++ b/src/python/lib/rmtc_core/io/filesystem/folders.py
@@ -2,7 +2,7 @@
 # Copyright Contributors to the RMTC Project
 
 """
-NOTE : 
+NOTE :
 These folder based datasets are for testing ONLY and
 will be removed shortly.
 

--- a/src/python/lib/rmtc_core/pipeline/filesystem/asset_managers.py
+++ b/src/python/lib/rmtc_core/pipeline/filesystem/asset_managers.py
@@ -53,4 +53,3 @@ class FilesystemManager(AssetManager):
 
     def resolve_inverse(self, uris):
         return self.resolve(uris)
-

--- a/src/python/lib/rmtc_core/track/cypher/connection.py
+++ b/src/python/lib/rmtc_core/track/cypher/connection.py
@@ -81,13 +81,11 @@ class CypherConnection(Connection):
         ids = []
         for entity in entities:
             ids.append(entity.obj_id)
-        result = self.write_query(
-            f"""
+        result = self.write_query(f"""
             MATCH (e) WHERE e._obj_id IN {ids}
             DETACH DELETE e
             RETURN count(e) AS deleted
-        """
-        )
+        """)
         for entity in entities:
             self.store.remove_entity(entity)
         if result is not None:
@@ -140,14 +138,12 @@ class CypherConnection(Connection):
             return []
         entities = []
         for obj_id in ids:
-            results = self.read_query(
-                f"""
+            results = self.read_query(f"""
                 MATCH (e) WHERE e._obj_id='{obj_id}'
                 RETURN
                 e._type_name AS type_name,
                 e._timestamp AS timestamp
-            """
-            )
+            """)
             if len(results) == 1:
                 result = results[0]
                 type_name = TypeName(result["type_name"])

--- a/src/python/lib/rmtc_core/train/torch/trainers.py
+++ b/src/python/lib/rmtc_core/train/torch/trainers.py
@@ -18,7 +18,6 @@ from rmtc.system import RMTCException, Context
 from rmtc.containers import ITable
 from rmtc.artifacts import ModelType
 
-
 MAX_SIGNED_32_INT = (1 << 31) - 1
 
 


### PR DESCRIPTION
## Summary
Applies black formatting to 13 files that were not compliant.

## Related
Closes #34

## Changes
- Applied `black src/` with `--target-version py312`
- 13 files reformatted, 92 files unchanged