### PR TITLE
fix: remove trailing newline from asset_managers.py

### DIFF
--- a/src/python/lib/rmtc_core/pipeline/filesystem/asset_managers.py
+++ b/src/python/lib/rmtc_core/pipeline/filesystem/asset_managers.py
@@ -53,4 +53,3 @@ class FilesystemManager(AssetManager):
 
     def resolve_inverse(self, uris):
         return self.resolve(uris)
-


### PR DESCRIPTION
## Problem
CI was failing with exit code 16 due to a trailing newline 
in asset_managers.py introduced in PR #32.

## Fix
Removed trailing newline from asset_managers.py.

## Related
Fixes CI failure introduced in #32