### PR TITLE
fix: add error handling code when $RTMC_CONFIG is required but not set

### DIFF
--- a/src/python/lib/rmtc/system.py
+++ b/src/python/lib/rmtc/system.py
@@ -1083,12 +1083,15 @@ class Config(IConfig):
         # If config path is not provided, load from the environment
         if config_file is None:
             env_var_path = os.environ.get(self.CONFIG_PATH_ENV_VAR, None)
-            env_paths = env_var_path.split(":")
-            for env_path in env_paths:
-                config_file = self._find_config_file(env_path)
-                if config_file is not None:
-                    break
-
+            if env_var_path is not None:
+                for env_path in env_var_path.split(":"):
+                    config_file = self._find_config_file(env_path)
+                    if config_file is not None:
+                        break
+        if config_file is None:
+            raise RMTCException(
+                f"Cannot find a valid RMTC config file in the current directory or from the {self.CONFIG_PATH_ENV_VAR} environment variable"
+            )
         return config_file
 
     def _find_config_file(self, path):

--- a/src/python/lib/rmtc/system.py
+++ b/src/python/lib/rmtc/system.py
@@ -1083,15 +1083,12 @@ class Config(IConfig):
         # If config path is not provided, load from the environment
         if config_file is None:
             env_var_path = os.environ.get(self.CONFIG_PATH_ENV_VAR, None)
-            if env_var_path is not None:
-                for env_path in env_var_path.split(":"):
-                    config_file = self._find_config_file(env_path)
-                    if config_file is not None:
-                        break
-        if config_file is None:
-            raise RMTCException(
-                f"Cannot find a valid RMTC config file in the current directory or from the {self.CONFIG_PATH_ENV_VAR} environment variable"
-            )
+            env_paths = env_var_path.split(":")
+            for env_path in env_paths:
+                config_file = self._find_config_file(env_path)
+                if config_file is not None:
+                    break
+
         return config_file
 
     def _find_config_file(self, path):

--- a/src/python/lib/rmtc/system.py
+++ b/src/python/lib/rmtc/system.py
@@ -1090,7 +1090,8 @@ class Config(IConfig):
                         break
         if config_file is None:
             raise RMTCException(
-                f"Cannot find a valid RMTC config file in the current directory or from the {self.CONFIG_PATH_ENV_VAR} environment variable"
+                "Cannot find a valid RMTC config file in the current directory or from " 
+                f"the {self.CONFIG_PATH_ENV_VAR} environment variable"
             )
         return config_file
 

--- a/src/python/lib/rmtc_core/__init__.py
+++ b/src/python/lib/rmtc_core/__init__.py
@@ -4,7 +4,6 @@
 import os
 
 from rmtc_core.track.cypher.neo4j import Neo4jDatabase
-from rmtc_core.track.cypher.age import AGEDatabase
 from rmtc_core.train.torch.trackers import TensorBoard
 from rmtc_core.pipeline.filesystem.asset_managers import FilesystemManager
 from rmtc_core.pipeline.onnx.builders import ONNXModelBuilder, ONNXWeightsBuilder
@@ -90,25 +89,14 @@ class System(rmtc.System):
                 store_uri = URI(store_config["uri"])
                 store_username = store_config["username"]
                 store_password = store_config["password"]
-                if store_config["type"] == "age":
-                    store = AGEDatabase(
-                        factory=factory,
-                        name=store_name,
-                        db_name=store_config.get("db_name", "postgresDB"),
-                        uri=store_uri,
-                        mode=mode,
-                        log=log,
-                        jit=jit,
-                    )
-                else:
-                    store = Neo4jDatabase(
-                        factory=factory,
-                        name=store_name,
-                        uri=store_uri,
-                        mode=mode,
-                        log=log,
-                        jit=jit,
-                    )
+                store = Neo4jDatabase(
+                    factory=factory,
+                    name=store_name,
+                    uri=store_uri,
+                    mode=mode,
+                    log=log,
+                    jit=jit,
+                )
             else:
                 log.warning("No store config found")
 

--- a/src/python/lib/rmtc_core/__init__.py
+++ b/src/python/lib/rmtc_core/__init__.py
@@ -4,6 +4,7 @@
 import os
 
 from rmtc_core.track.cypher.neo4j import Neo4jDatabase
+from rmtc_core.track.cypher.age import AGEDatabase
 from rmtc_core.train.torch.trackers import TensorBoard
 from rmtc_core.pipeline.filesystem.asset_managers import FilesystemManager
 from rmtc_core.pipeline.onnx.builders import ONNXModelBuilder, ONNXWeightsBuilder
@@ -89,14 +90,25 @@ class System(rmtc.System):
                 store_uri = URI(store_config["uri"])
                 store_username = store_config["username"]
                 store_password = store_config["password"]
-                store = Neo4jDatabase(
-                    factory=factory,
-                    name=store_name,
-                    uri=store_uri,
-                    mode=mode,
-                    log=log,
-                    jit=jit,
-                )
+                if store_config["type"] == "age":
+                    store = AGEDatabase(
+                        factory=factory,
+                        name=store_name,
+                        db_name=store_config.get("db_name", "postgresDB"),
+                        uri=store_uri,
+                        mode=mode,
+                        log=log,
+                        jit=jit,
+                    )
+                else:
+                    store = Neo4jDatabase(
+                        factory=factory,
+                        name=store_name,
+                        uri=store_uri,
+                        mode=mode,
+                        log=log,
+                        jit=jit,
+                    )
             else:
                 log.warning("No store config found")
 


### PR DESCRIPTION
This PR adds error handling to `Config._find_config()` when the `RTMC_CONFIG` environment variable is required but not set. 
Instead of failing with an exception when calling .split(":") on a None value, the code now raises a more readable RMTCException.