### PR TITLE
feat: minimal ci tests

### DIFF
--- a/.github/rmtc-config-ci-tests.yaml
+++ b/.github/rmtc-config-ci-tests.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the RMTC Project
+
+# RMTC system config
+# Anything added in here will appear in the config dict
+
+# Config metadata
+_type:          config
+_version:       1.0.0
+_name:          rmtc
+
+# Internal system state
+rmtc_system:
+  jit_sync:     true    
+  mode:         DEVELOPMENT
+
+# Change these credentials
+rmtc_store:
+  type:         age
+  username:     postgres
+  password:     postgres
+  uri:          postgres://localhost:5432
+  name:         postgresDB
+
+  # Show/project mapping (store name: project code(s))
+  store_map:
+    rmtc_example:
+      - show
+
+rmtc_tracker:
+  uri:          ./rmtc_tracker_storage
+
+rmtc_log:
+  type_name:    logger
+  level:        DEBUG

--- a/.github/rmtc-config-ci-tests.yaml
+++ b/.github/rmtc-config-ci-tests.yaml
@@ -1,20 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the RMTC Project
 
-# RMTC system config
-# Anything added in here will appear in the config dict
+# RMTC system config - used exclusively by CI test workflows (ci_tests.yaml, ci_code_quality.yaml)
 
 # Config metadata
 _type:          config
 _version:       1.0.0
 _name:          rmtc
 
-# Internal system state
 rmtc_system:
-  jit_sync:     true    
+  jit_sync:     true
   mode:         DEVELOPMENT
 
-# Change these credentials
+# Credentials and URI match the Apache AGE service container defined in the CI workflow files.
+# Do not change these without updating the corresponding workflow service definitions.
 rmtc_store:
   type:         age
   username:     postgres
@@ -28,8 +27,8 @@ rmtc_store:
       - show
 
 rmtc_tracker:
-  uri:          ./rmtc_tracker_storage
+  uri:          ./rmtc_tracker_storage  # write TensorBoard logs to a local temp dir on the CI runner
 
 rmtc_log:
   type_name:    logger
-  level:        DEBUG
+  level:        DEBUG                   # verbose logging to aid CI failure diagnosis

--- a/.github/workflows/ci_code_quality.yaml
+++ b/.github/workflows/ci_code_quality.yaml
@@ -4,9 +4,9 @@ name: CI
 
 on:
   push:
-    # All pushes, including stacked PRs' pushes
+    branches: [main, develop]
   pull_request:
-    # All PRs, including stacked PRs
+    branches: [main, develop]
 
 jobs:
   lint:
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -23,10 +23,11 @@ jobs:
           python-version: "3.11"
           cache: pip
 
-      - name: Install Code Quality Scan dependencies
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install black pylint pip-audit
+          pip install -e ".[dev]" --no-deps
 
       - name: Lint (pylint)
         run: pylint src/

--- a/.github/workflows/ci_code_quality.yaml
+++ b/.github/workflows/ci_code_quality.yaml
@@ -4,9 +4,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    # All pushes, including stacked PRs' pushes
   pull_request:
-    branches: [main, develop]
+    # All PRs, including stacked PRs
 
 jobs:
   lint:
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -23,11 +23,10 @@ jobs:
           python-version: "3.11"
           cache: pip
 
-      - name: Install dependencies
+      - name: Install Code Quality Scan dependencies
         run: |
           python -m pip install --upgrade pip
           pip install black pylint pip-audit
-          pip install -e ".[dev]" --no-deps
 
       - name: Lint (pylint)
         run: pylint src/

--- a/.github/workflows/ci_code_quality.yaml
+++ b/.github/workflows/ci_code_quality.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the RMTC Project
-name: CI
+name: CI_Code_Quality
 
 on:
   push:

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       RMTC_CONFIG: .github/rmtc-config-ci-tests.yaml
+      RMTC_MODULES: res/modules
 
     strategy:
       fail-fast: false
@@ -62,6 +63,4 @@ jobs:
       
       - name: Run tests
         run: |
-          # Ignore test_011_entities.py for now due to age store connection issues; 
-          # will be re-enabled in a future PR
-          uv run uv run pytest tests/unit/ --ignore=tests/unit/test_011_entities.py  
+          uv run uv run pytest tests/unit/ 

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Contributors to the RMTC Project
-name: CI
+name: CI_Tests
 
 on:
   push:

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -7,7 +7,6 @@ on:
     branches: 
       - main
       - develop
-      - feat/minimal-ci-tests
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -7,6 +7,7 @@ on:
     branches: 
       - main
       - develop
+      - feat/minimal-ci-tests
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the RMTC Project
+name: CI
+
+on:
+  push:
+    branches: 
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  tests:
+    name: "Tests"
+    runs-on: ubuntu-22.04
+    env:
+      RMTC_CONFIG: .github/rmtc-config-ci-tests.yaml
+
+    strategy:
+      fail-fast: false
+      matrix:
+          python-version:
+            - "3.9"
+            - "3.11"
+            - "3.12"
+
+    services:
+      age:
+        image: apache/age@sha256:4241e2d8bb86a6b2ea44e9ad06c73856e12b209de295124603a599dd7feb70eb
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgresDB
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false  # prevent credentials from persisting in the workspace
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpq-dev postgresql-client-common postgresql-client
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0; uv 0.11.14
+        with:
+          version: "0.11.14"
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install python dependencies
+        run: |
+          uv venv --python python${{ matrix.python-version }}
+          uv pip install -e ".[dev]"
+      
+      - name: Run tests
+        run: |
+          # Ignore test_011_entities.py for now due to age store connection issues; 
+          # will be re-enabled in a future PR
+          uv run uv run pytest tests/unit/ --ignore=tests/unit/test_011_entities.py  

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -19,6 +19,7 @@ jobs:
     env:
       RMTC_CONFIG: .github/rmtc-config-ci-tests.yaml
       RMTC_MODULES: res/modules
+      RMTC_RESOURCES: res
 
     strategy:
       fail-fast: false
@@ -61,6 +62,10 @@ jobs:
           uv venv --python python${{ matrix.python-version }}
           uv pip install -e ".[dev]"
       
-      - name: Run tests
+      - name: Run unit tests
         run: |
-          uv run uv run pytest tests/unit/ 
+          uv run pytest tests/unit/ 
+
+      - name: Run integration tests
+        run: |
+          uv run pytest tests/integration/ --ignore=tests/integration/test_200_mnist_refine_model.py

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ You also need to set `RMTC_MODULES` to the directory containing the module regis
 export RMTC_MODULES=res/modules
 ```
 
+The `RMTC_RESOURCES` environment variable points to the resource directory, commonly used for test fixtures: 
+
+```bash
+export RMTC_RESOURCES=res
+```
+
 To test simply call `rmtc-gui` which should bring up the ingestion, train, track & trace UI. This will be empty at first.
 
 You can also run `pytest` from the root of the project to run the unit tests.

--- a/README.md
+++ b/README.md
@@ -60,33 +60,30 @@ cmake -DCMAKE_INSTALL_PREFIX=$HOME/.local -B cmake/build -S .
 cd cmake/build
 make install
 source ./rmtc-setup.bash
+cd -
 ```
 
 _Note_: You can replace `$HOME/.local` in the cmake command above with your installation directory of choice.
 
 This will clone the repo into your code folder, create build info in cmake/build, then make and install into a given path. The final shell script source sets up the envvars required to execute. 
 
-However, before running, you will need to create a config file for your age installation derived from the [template](/res/config/rmtc_config.yaml), the RMTC_CONFIG environment variable points RMTC to the config path, which you can override as follows:
+However, before running, you will need to create a config file for your age installation derived from the [template](res/config/rmtc-config.yaml), the RMTC_CONFIG environment variable points RMTC to the config path, which you can override as follows:
 
 ```bash
-setenv RMTC_CONFIG=<config path>/<config_name>.yaml
+# csh / tcsh
+setenv RMTC_CONFIG <config path>/<config_name>.yaml
+
+# sh / bash / zsh
+export RMTC_CONFIG=<config path>/<config_name>.yaml
 ```
 
-You also need to set `RMTC_MODULES` to the directory containing the module registry YAML files. The default registry is in `res/modules/` and tells the `ModuleFactory` how to resolve type names to concrete implementations:
+You also need to set `RMTC_MODULES` environment variable to the directory containing the module registry YAML files. A common choice is `./res/modules/`.
 
-```bash
-export RMTC_MODULES=res/modules
-```
-
-The `RMTC_RESOURCES` environment variable points to the resource directory, commonly used for test fixtures: 
-
-```bash
-export RMTC_RESOURCES=res
-```
+The environment variable `RMTC_RESOURCES` points to the resource directory, commonly used for test fixtures. A common choice is `./res`
 
 To test simply call `rmtc-gui` which should bring up the ingestion, train, track & trace UI. This will be empty at first.
 
-You can also run `pytest` from the root of the project to run the unit tests.
+You can also run `pytest` from the root of the project to run the unit tests and integration tests.
 
 ## Dependencies
 See [pyproject](pyproject.toml) for a list of dependencies in machine readible format - these are not configured, found or installed as part of the build currently.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ However, before running, you will need to create a config file for your age inst
 setenv RMTC_CONFIG=<config path>/<config_name>.yaml
 ```
 
+You also need to set `RMTC_MODULES` to the directory containing the module registry YAML files. The default registry is in `res/modules/` and tells the `ModuleFactory` how to resolve type names to concrete implementations:
+
+```bash
+export RMTC_MODULES=res/modules
+```
+
 To test simply call `rmtc-gui` which should bring up the ingestion, train, track & trace UI. This will be empty at first.
 
 You can also run `pytest` from the root of the project to run the unit tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dependencies = [
 
     # Infer
     "onnx>=1.16.0",
-    "onnxruntime>=1.19.0",
+    "onnxruntime<=1.18.0; python_version <= '3.9'",
+    "onnxruntime>=1.19.0; python_version >= '3.10'",
     "onnxscript>=0.2.0",
 ]
 
@@ -50,7 +51,8 @@ dev = [
     "pytest>=8.3.0",
     "pylint>=3.3.0",
     "black>=24.8.0",
-    "pip-audit>=2.10.0",
+    "pip-audit>=2.9.0; python_version == '3.9'",
+    "pip-audit>=2.10.0; python_version >= '3.10'",
 ]
 
 [tool.setuptools]

--- a/src/python/lib/rmtc/system.py
+++ b/src/python/lib/rmtc/system.py
@@ -1083,11 +1083,16 @@ class Config(IConfig):
         # If config path is not provided, load from the environment
         if config_file is None:
             env_var_path = os.environ.get(self.CONFIG_PATH_ENV_VAR, None)
-            env_paths = env_var_path.split(":")
-            for env_path in env_paths:
-                config_file = self._find_config_file(env_path)
-                if config_file is not None:
-                    break
+            if env_var_path is not None:
+                for env_path in env_var_path.split(":"):
+                    config_file = self._find_config_file(env_path)
+                    if config_file is not None:
+                        break
+        if config_file is None:
+            raise RMTCException(
+                "Cannot find a valid RMTC config file in the current directory or from"
+                f" the {self.CONFIG_PATH_ENV_VAR} environment variable"
+            )
 
         return config_file
 

--- a/src/python/lib/rmtc/system.py
+++ b/src/python/lib/rmtc/system.py
@@ -1083,16 +1083,11 @@ class Config(IConfig):
         # If config path is not provided, load from the environment
         if config_file is None:
             env_var_path = os.environ.get(self.CONFIG_PATH_ENV_VAR, None)
-            if env_var_path is not None:
-                for env_path in env_var_path.split(":"):
-                    config_file = self._find_config_file(env_path)
-                    if config_file is not None:
-                        break
-        if config_file is None:
-            raise RMTCException(
-                "Cannot find a valid RMTC config file in the current directory or from"
-                f" the {self.CONFIG_PATH_ENV_VAR} environment variable"
-            )
+            env_paths = env_var_path.split(":")
+            for env_path in env_paths:
+                config_file = self._find_config_file(env_path)
+                if config_file is not None:
+                    break
 
         return config_file
 

--- a/src/python/lib/rmtc_core/__init__.py
+++ b/src/python/lib/rmtc_core/__init__.py
@@ -3,6 +3,7 @@
 
 import os
 
+from rmtc_core.track.cypher.age import AGEDatabase
 from rmtc_core.track.cypher.neo4j import Neo4jDatabase
 from rmtc_core.train.torch.trackers import TensorBoard
 from rmtc_core.pipeline.filesystem.asset_managers import FilesystemManager
@@ -89,14 +90,25 @@ class System(rmtc.System):
                 store_uri = URI(store_config["uri"])
                 store_username = store_config["username"]
                 store_password = store_config["password"]
-                store = Neo4jDatabase(
-                    factory=factory,
-                    name=store_name,
-                    uri=store_uri,
-                    mode=mode,
-                    log=log,
-                    jit=jit,
-                )
+                if store_config["type"] == "age":
+                    store = AGEDatabase(
+                        factory=factory,
+                        name=store_name,
+                        db_name=store_config.get("db_name", "postgresDB"),
+                        uri=store_uri,
+                        mode=mode,
+                        log=log,
+                        jit=jit,
+                    )
+                else:
+                    store = Neo4jDatabase(
+                        factory=factory,
+                        name=store_name,
+                        uri=store_uri,
+                        mode=mode,
+                        log=log,
+                        jit=jit,
+                    )
             else:
                 log.warning("No store config found")
 


### PR DESCRIPTION
## Add minimal CI testing
Sets up a basic CI pipeline for the project and adds the supporting code and dependency changes needed to make it run.

A summary of the CI unit and integration test workflow can be found here:
https://github.com/MilesBay/rmtc_dev_homebrew/actions/runs/27155718949

## Changes

### 1. CI workflow (ci_tests.yaml)

- Tests against a Python version matrix: 3.9, 3.11, and 3.12 on Ubuntu 22.
- Spins up an Apache AGE (Postgres-based graph DB) instance as a service container for integration tests.
- Uses uv to manage the virtual environment and install dependencies.
- Renames `ci.yaml` to `ci_code_quality.yaml`

### 2. AGE store backend support (rmtc_core/__init__.py)

- Adds a short term solution to load `AGEDatabase` when `rmtc_config.yaml`'s `.rmtc_store.type` is age.

### 3. Version-specific dependency constraints (pyproject.toml)

- Splits a few dependencies by Python version using environment markers, since the newer releases don't support 3.9:
  - onnxruntime: <=1.18.0 on 3.9, >=1.19.0 on 3.10+.
  - pip-audit: 2.9 on 3.9, 2.10 on 3.10+.

### 4. adjust documentation (README.md)


## Known limitations

- One integration test `test_200_mnist_refine_model.py` is currently excluded from CI execution — The issue is tracked in [issue #30](https://github.com/AcademySoftwareFoundation/rmtc/issues/30).
- Switching between AGEDatabase and Neo4jDatabase currently relies on a temporary workaround and should be revisited in a future refactor.